### PR TITLE
Implement REST API access control within security plugin

### DIFF
--- a/inc/rest-api.php
+++ b/inc/rest-api.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Manage Content-Security-Policy and related HTTP headers.
+ */
+
+declare( strict_types=1 );
+
+namespace WMF\Security\REST_API;
+
+use WP_REST_Response;
+use WP_Error;
+use WP_REST_Request;
+
+/**
+ * Connect namespace functions to actions and filters.
+ */
+function bootstrap() {
+	add_action( 'rest_request_before_callbacks', __NAMESPACE__ . '\\restrict_anonymous_rest_api_access', 10, 3 );
+}
+
+/**
+ * Restrict public REST API access.
+ *
+ * Used to pass a WP_Error back to the API when request is not authenticated.
+ *
+ * @param \WP_REST_Response|WP_Error|mixed $response Result to send to the client.
+ * @param array                            $handler  Route handler used for the request.
+ * @param WP_REST_Request                  $request  Request used to generate the response.
+ *
+ * @return WP_Error|null|true
+ */
+function restrict_anonymous_rest_api_access( $response, array $handler, WP_REST_Request $request ) {
+	// Check if a previous authentication was applied and pass that result
+	// without modification.
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	// Return an unauthorized response error if user does not have editing capabilities.
+	if ( ! current_user_can( 'edit_posts' ) ) {
+		/**
+		 * Filter which API endpoint requests can be fulfilled without authentication.
+		 *
+		 * This enables specific routes to be made publicly accessible if they
+		 * are required for frontend site functionality, such as vega-lite CSV
+		 * dataset endpoints.
+		 *
+		 * @param bool            $is_allowed Whether the endpoint is publicly accessible, false by default.
+		 * @param WP_REST_Request $request    Active REST Request object.
+		 */
+		$is_allowed_request = apply_filters( 'wmf/security/rest_api/public_endpoint', false, $request );
+
+		if ( ! $is_allowed_request ) {
+			return new WP_Error(
+				'rest_disabled',
+				__( 'You do not have permission to access the REST API.', 'wmf-rest-api' ),
+				[ 'status' => rest_authorization_required_code() ]
+			);
+		}
+	}
+
+	return $response;
+}

--- a/plugin.php
+++ b/plugin.php
@@ -5,6 +5,7 @@
  * Author: The Wikimedia Foundation and Human Made
  * Author URI: https://github.com/wikimedia/wikimedia-wordpress-security-plugin/graphs/contributors
  * Version: 1.0.0
+ * Text Domain: wikimedia-security
  */
 
 declare( strict_types=1 );
@@ -14,6 +15,8 @@ namespace WMF\Security;
 require_once __DIR__ . '/inc/http-headers.php';
 require_once __DIR__ . '/inc/plugin-integration/jetpack.php';
 require_once __DIR__ . '/inc/csp.php';
+require_once __DIR__ . '/inc/rest-api.php';
 
 HTTP_Headers\bootstrap();
 Plugin_Integration\Jetpack\bootstrap();
+REST_API\bootstrap();


### PR DESCRIPTION
Implements REST API access control within the plugin, with an escape-hatch filter which may be used to opt certain endpoints like the [vega-lite plugin's datasets](/wikimedia/vega-lite-wordpress-plugin) into being publicly readable.

WIP: Needs documentation in README.