### PR TITLE
Update CSP to allow images from wikimediafoundation.org

### DIFF
--- a/inc/csp.php
+++ b/inc/csp.php
@@ -155,6 +155,7 @@ function allow_video_service_origins( array $allowed_origins, string $policy_typ
 function allow_wikimedia_origins( array $allowed_origins, string $policy_type ): array {
 	if ( in_array( $policy_type, [ 'script-src', 'style-src', 'img-src' ], true ) ) {
 		$allowed_origins[] = 'https://*.wikimedia.org';
+		$allowed_origins[] = 'https://wikipedia.org';
 	}
 
 	// Explicitly allow images from wikimediafoundation.org uploads directory

--- a/inc/csp.php
+++ b/inc/csp.php
@@ -145,7 +145,8 @@ function allow_video_service_origins( array $allowed_origins, string $policy_typ
 }
 
 /**
- * Permit certain resources from *.wikimedia.org necessary for Matomo tracking.
+ * Permit resources from *.wikimedia.org and wikimediafoundation.org
+ * necessary for Matomo tracking and images.
  *
  * @param string[] $allowed_origins List of origins to allow in this CSP.
  * @param string   $policy_type     CSP type.
@@ -155,6 +156,13 @@ function allow_wikimedia_origins( array $allowed_origins, string $policy_type ):
 	if ( in_array( $policy_type, [ 'script-src', 'style-src', 'img-src' ], true ) ) {
 		$allowed_origins[] = 'https://*.wikimedia.org';
 	}
+
+	// Explicitly allow images from wikimediafoundation.org uploads directory
+	if ( $policy_type === 'img-src' ) {
+		$allowed_origins[] = 'https://wikimediafoundation.org';
+		$allowed_origins[] = 'https://wikimediafoundation.org/wp-content/uploads';
+	}
+
 	return $allowed_origins;
 }
 


### PR DESCRIPTION
We found some errors when using the option `--media-redirect-domain=wikimediafoundation.org` for loading remote images on a local environment, refered on [Wikimedia Local Development Setup](https://github.com/humanmade/wikimedia/wiki/Local-development-setup). This change is expected to fix that.

```
wikimedia.vipdev.lndo.site/:1 Refused to load the image 'https://wikimediafoundation.org/wp-content/uploads/2018/07/Screen-Shot-2018-07-30-at-1.24.58-PM-e1533254033550.png?w=600&h=338&crop=1' because it violates the following Content Security Policy directive: "img-src 'self' data: https://*.wikimedia.org https://*.wp.com".