### PR TITLE
1.1.0 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ add_filter( 'wmf/security/csp/allowed_origins', __NAMESPACE__ . '\\permit_custom
  * @return string[] Filtered list of permitted origins.
  */
 function permit_custom_video_provider( array $allowed_origins, string $policy_type ) : array {
-	if ( in_array( $policy_type, [ 'script-src', 'frame-src' ], true ) {
+	if ( in_array( $policy_type, [ 'script-src', 'frame-src' ], true ) ) {
 		$allowed_origins[] = 'https://player.necessary-video-service.com';
 	}
 	return $allowed_origins;

--- a/inc/csp.php
+++ b/inc/csp.php
@@ -8,9 +8,9 @@ declare( strict_types=1 );
 namespace WMF\Security\CSP;
 
 // Maintain a list of permitted non-URL-shaped source keywords for use in policy directives.
-// Does not include 'self', which we allow by default on filtered directives.
 // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy.
 const KEYWORD_SOURCE_VALUES = [
+	"'self'", // Allow resources from the current origin.
 	"'none'", // Won't allow loading of any resources.
 	"'strict-dynamic'", // Extend trust granted to a script on the page to scripts it loads.
 	"'report-sample'", // Require a sample of violating code to be included in violation reports.
@@ -42,12 +42,12 @@ function bootstrap(): void {
  */
 function render_csp_directives_string( string $policy_type ): string {
 	/**
-	 * Customize allowed origins for a ...-src CSP.
+	 * Customize allowed origins for a ...-src CSP. Always start with 'self'.
 	 *
 	 * @param string[] $allowed_origins List of origins to allow in this CSP.
 	 * @param string   $policy_type     CSP type.
 	 */
-	$allowed_origins = apply_filters( 'wmf/security/csp/allowed_origins', [], $policy_type );
+	$allowed_origins = apply_filters( 'wmf/security/csp/allowed_origins', [ "'self'" ], $policy_type );
 
 	// Strip out entries that the validator returned as empty.
 	$allowed_origins = array_filter(
@@ -89,9 +89,6 @@ function render_csp_directives_string( string $policy_type ): string {
 	if ( apply_filters( 'wmf/security/csp/allow_data_uris', false, $policy_type ) ) {
 		array_unshift( $allowed_origins, 'data:' );
 	}
-
-	// Always allow 'self'.
-	array_unshift( $allowed_origins, "'self'" );
 
 	// Prefix with policy type, and return complete policy directives string.
 	return "$policy_type " . implode( ' ', $allowed_origins );

--- a/inc/csp.php
+++ b/inc/csp.php
@@ -300,6 +300,7 @@ function add_csp_headers( array $headers ) {
 			'img-src',
 			'script-src',
 			'style-src',
+			'worker-src',
 		]
 	);
 

--- a/inc/csp.php
+++ b/inc/csp.php
@@ -109,7 +109,7 @@ function validate_and_sanitize_csp_origin( string $url ): string {
 		return '';
 	}
 
-	$port = ! empty( $components['port'] ) ? ( '' . $components['port'] ) : '';
+	$port = ! empty( $components['port'] ) ? ( ':' . $components['port'] ) : '';
 	return sprintf( '%s://%s%s', $scheme, $host, $port );
 }
 

--- a/inc/csp.php
+++ b/inc/csp.php
@@ -192,7 +192,7 @@ function allow_wikimedia_origins( array $allowed_origins, string $policy_type ):
  */
 function set_connect_src_origins( array $allowed_origins, string $policy_type ): array {
 	if ( $policy_type === 'connect-src' ) {
-		return [ 'https://*.wikipedia.org', 'wss://*.wordpress.com' ];
+		return [ 'https://*.wikipedia.org', 'https://*.wikimedia.org', 'wss://*.wordpress.com' ];
 	}
 	return $allowed_origins;
 }

--- a/inc/csp.php
+++ b/inc/csp.php
@@ -104,8 +104,13 @@ function validate_and_sanitize_csp_origin( string $url ): string {
 		return '';
 	}
 
-	if ( ! in_array( $scheme, [ 'http', 'https', 'wss' ], true ) ) {
-		// Only support http:, https:, and wss: schemes at this time.
+	// Only support https:, and wss: schemes at this time.
+	// Permit less-secure http and ws connections only in local environments.
+	$allowed_schemes = [ 'https', 'wss' ];
+	if ( wp_get_environment_type() === 'local' ) {
+		$allowed_schemes = [ ...$allowed_schemes, 'http', 'ws' ];
+	}
+	if ( ! in_array( $scheme, $allowed_schemes, true ) ) {
 		return '';
 	}
 

--- a/inc/csp.php
+++ b/inc/csp.php
@@ -199,8 +199,8 @@ function set_connect_src_origins( array $allowed_origins, string $policy_type ):
 }
 
 /**
- * When the environment type is "local", add localhost origins to CSP headers
- * and permit proxying media requests through to deployed environment.
+ * When the environment type is "local", add localhost origins with commonly-
+ * used ports to CSP headers.
  *
  * @param string[] $allowed_origins List of origins to allow in this CSP.
  * @param string   $policy_type     CSP type.
@@ -222,16 +222,6 @@ function maybe_add_local_dev_origins( array $allowed_origins, string $policy_typ
 		] as $local_dev_origin ) {
 			$allowed_origins[] = $local_dev_origin;
 		}
-	}
-
-	if ( $policy_type === 'img-src' ) {
-		/**
-		 * Permit proxying images through to production or to preprod.
-		 *
-		 * @see https://docs.wpvip.com/how-tos/dev-env-add-media/#h-proxy-media-files
-		 */
-		$allowed_origins[] = 'https://wikimediafoundation.org';
-		$allowed_origins[] = 'https://wikimediafoundation-org-preprod.go-vip.net';
 	}
 
 	return $allowed_origins;

--- a/inc/csp.php
+++ b/inc/csp.php
@@ -15,6 +15,7 @@ const KEYWORD_SOURCE_VALUES = [
 	"'strict-dynamic'", // Extend trust granted to a script on the page to scripts it loads.
 	"'report-sample'", // Require a sample of violating code to be included in violation reports.
 	"'inline-speculation-rules'", // Allows the inclusion of speculation rules in scripts.
+	'blob:', // Not a keyword per se, but a valid URL scheme source for worker-src specifically.
 ];
 
 /**

--- a/inc/csp.php
+++ b/inc/csp.php
@@ -309,6 +309,7 @@ function add_csp_headers( array $headers ) {
 		"base-uri 'self'",
 		"form-action 'self'",
 		"frame-ancestors 'none'",
+		"object-src 'none'",
 		'block-all-mixed-content',
 	];
 

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Deploys security related code to Wikimedia Foundation sites hosted on WordPress VIP.
  * Author: The Wikimedia Foundation and Human Made
  * Author URI: https://github.com/wikimedia/wikimedia-wordpress-security-plugin/graphs/contributors
- * Version: 1.0.0
+ * Version: 1.1.0
  * Text Domain: wikimedia-security
  */
 


### PR DESCRIPTION
This PR bundles a number of modifications to this plugin which have become necessary as the plugin seems more usage across Wikimedia website properties.

- Fix a typo in the README sample code which prevented it from working out of the box
- Fix a bug where a colon would be stripped out of URLs containing ports (fixes humanmade/wikimedia#965)
- Allow injection of valid keyword source strings like `'strict-dynamic'` using this plugin
- Allow configuration of `worker-src` directives using this plugin
- Permit `blob:` URLs for use in `worker-src` directive (supports Report plugin)
- Remove web-project-specific environment URLs (fixes #13)
- Alter how `'self'` directive is added to the directive array to permit it to be filtered later if needed
- Only allow insecure `http:` and `ws:` schemes in local environments
- Set `object-src 'none'` as [recommended by MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src)
- Allow `*.wikimedia.org` in `connect-src` by default to permit first-party instrumentation