### PR TITLE
Fix issue where "self" was removed from connect-src CSP directive in 1.1.0

### DIFF
--- a/inc/csp.php
+++ b/inc/csp.php
@@ -190,7 +190,9 @@ function allow_wikimedia_origins( array $allowed_origins, string $policy_type ):
  */
 function set_connect_src_origins( array $allowed_origins, string $policy_type ): array {
 	if ( $policy_type === 'connect-src' ) {
-		return [ 'https://*.wikipedia.org', 'https://*.wikimedia.org', 'wss://*.wordpress.com' ];
+		$allowed_origins[] = 'https://*.wikipedia.org';
+		$allowed_origins[] = 'https://*.wikimedia.org';
+		$allowed_origins[] = 'wss://*.wordpress.com';
 	}
 	return $allowed_origins;
 }

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Deploys security related code to Wikimedia Foundation sites hosted on WordPress VIP.
  * Author: The Wikimedia Foundation and Human Made
  * Author URI: https://github.com/wikimedia/wikimedia-wordpress-security-plugin/graphs/contributors
- * Version: 1.1.0
+ * Version: 1.1.1
  * Text Domain: wikimedia-security
  */
 


### PR DESCRIPTION
We switched from passing `'self'` in as the default value in the filter, but this existing code returns a whole new array which does not contain the prior values. Doing that removes `self` and blocks REST-API requests.