### PR TITLE
Allow "self" frame ancestors to fix customizer

### DIFF
--- a/inc/csp.php
+++ b/inc/csp.php
@@ -298,7 +298,7 @@ function add_csp_headers( array $headers ) {
 	$csp_invariate_policies = [
 		"base-uri 'self'",
 		"form-action 'self'",
-		"frame-ancestors 'none'",
+		"frame-ancestors 'self'",
 		"object-src 'none'",
 		'block-all-mixed-content',
 	];


### PR DESCRIPTION
The WordPress customizer uses an iframe to embed the site, so we need to permit "self" ancestors on the CSP frame directive.

WIKI-1052