### PR TITLE
Update actions/cache to non deprecated version

### DIFF
--- a/.github/workflows/php-standards.yml
+++ b/.github/workflows/php-standards.yml
@@ -50,7 +50,7 @@ jobs:
           composer install --prefer-dist --no-progress --no-suggest --no-interaction
 
       - name: PHPCS cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: tests/cache
           key: ${{ runner.os }}-phpcs-7.2-${{ hashFiles('plugin.php') }}


### PR DESCRIPTION
Action runs were failing due to a deprecated actions/cache version.

Updating to 4.2.3