### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/php-standards.yml
+++ b/.github/workflows/php-standards.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install PHP
-        uses: shivammathur/setup-php@e6f75134d35752277f093989e72e140eaa222f35 # v2.28.0
+        uses: shivammathur/setup-php@fcafdd6392932010c2bd5094439b8e33be2a8a09 # v2.37.0
         with:
           php-version: '8.1'
           coverage: none
@@ -40,7 +40,7 @@ jobs:
 
       - name: Cache PHP Dependencies
         id: composer-cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ${{ steps.composer-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-composer-7.2-${{ hashFiles('composer.lock') }}
@@ -50,7 +50,7 @@ jobs:
           composer install --prefer-dist --no-progress --no-suggest --no-interaction
 
       - name: PHPCS cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: tests/cache
           key: ${{ runner.os }}-phpcs-7.2-${{ hashFiles('plugin.php') }}


### PR DESCRIPTION
GitHub actions are failing due to a deprecated action (actions/cache). This PR updates actions to resolve the issue.