### PR TITLE
1057 allow social embeds from Instagram and Bluesky

### DIFF
--- a/inc/csp.php
+++ b/inc/csp.php
@@ -178,16 +178,18 @@ function allow_video_service_origins( array $allowed_origins, string $policy_typ
  * @return string[] Filtered policy allowed origins array.
  */
 function allow_social_embed_origins( array $allowed_origins, string $policy_type ): array {
-	if ( in_array( $policy_type, [ 'frame-src', 'script-src' ], true ) ) {
-
-		// Allow embeds of Instagram posts and reels.
-		$allowed_origins[] = 'https://platform.instagram.com';
-		$allowed_origins[] = 'https://www.instagram.com';
-
-		// Allow Bluesky embeds
-		$allowed_origins[] = 'https://embed.bsky.app';
+	if ( ! in_array( $policy_type, [ 'frame-src', 'script-src' ], true ) ) {
+		return $allowed_origins;
 	}
-	return $allowed_origins;
+
+	// Allow embeds of Instagram posts and reels.
+	$allowed_origins[] = 'https://platform.instagram.com';
+	$allowed_origins[] = 'https://www.instagram.com';
+
+	// Allow Bluesky embeds
+	$allowed_origins[] = 'https://embed.bsky.app';
+
+	return array_unique( $allowed_origins );
 }
 
 /**

--- a/inc/csp.php
+++ b/inc/csp.php
@@ -27,6 +27,7 @@ function bootstrap(): void {
 	// Per-policy customizations.
 	add_filter( 'wmf/security/csp/allowed_origins', __NAMESPACE__ . '\\allow_vip_origin', 10, 2 );
 	add_filter( 'wmf/security/csp/allowed_origins', __NAMESPACE__ . '\\allow_video_service_origins', 10, 2 );
+	add_filter( 'wmf/security/csp/allowed_origins', __NAMESPACE__ . '\\allow_social_embed_origins', 10, 2 );
 	add_filter( 'wmf/security/csp/allowed_origins', __NAMESPACE__ . '\\maybe_add_local_dev_origins', 10, 2 );
 	add_filter( 'wmf/security/csp/allowed_origins', __NAMESPACE__ . '\\allow_wikimedia_origins', 10, 2 );
 	add_filter( 'wmf/security/csp/allowed_origins', __NAMESPACE__ . '\\set_connect_src_origins', 10, 2 );
@@ -163,6 +164,28 @@ function allow_video_service_origins( array $allowed_origins, string $policy_typ
 	if ( in_array( $policy_type, [ 'frame-src', 'script-src' ], true ) ) {
 		$allowed_origins[] = 'https://www.youtube.com';
 		$allowed_origins[] = 'https://player.vimeo.com';
+	}
+	return $allowed_origins;
+}
+
+/**
+ * Add social embed origins to script-src and frame-src directives:
+ * - Instagram
+ * - Bluesky
+ *
+ * @param string[] $allowed_origins List of origins to allow in this CSP.
+ * @param string   $policy_type     CSP type.
+ * @return string[] Filtered policy allowed origins array.
+ */
+function allow_social_embed_origins( array $allowed_origins, string $policy_type ): array {
+	if ( in_array( $policy_type, [ 'frame-src', 'script-src' ], true ) ) {
+
+		// Allow embeds of Instagram posts and reels.
+		$allowed_origins[] = 'https://platform.instagram.com';
+		$allowed_origins[] = 'https://www.instagram.com';
+
+		// Allow Bluesky embeds
+		$allowed_origins[] = 'https://embed.bsky.app';
 	}
 	return $allowed_origins;
 }


### PR DESCRIPTION
Allows social embeds from Instagram and Bluesky, using the `script-src` and `frame-src` directives.